### PR TITLE
Skip optional dependencies during npm install

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+omit=optional


### PR DESCRIPTION
## Summary
- `node-sass` was still getting pulled in transitively — `react-scripts` bundles `sass-loader`, which lists `node-sass` as an **optional** dependency (for projects that want it). Even marked optional, Vercel's `npm install` was failing hard trying to compile it (`node-gyp` vs Python 3.12's removed `distutils`).
- Adds `.npmrc` with `omit=optional` so npm never attempts optional deps at all. The project doesn't use Sass, so nothing is lost.

## Test plan
- [x] `rm -rf node_modules && npm install` — no node-sass build attempt, `node-sass` absent from `node_modules`
- [x] `npm run build` succeeds
