### PR TITLE
Remove Firebase dependency from the app

### DIFF
--- a/src/App/About/Components/uploadPhotos.js
+++ b/src/App/About/Components/uploadPhotos.js
@@ -3,10 +3,6 @@
 import React, { useEffect, useState } from "react";
 import { useNavigate } from "react-router";
 import { useSelector } from "react-redux";
-import { storage, db } from "../../../firebase-config";
-import { ref, uploadBytesResumable, getDownloadURL } from "firebase/storage";
-import { doc, setDoc, collection, getDocs } from "firebase/firestore";
-import Compressor from "compressorjs";
 import {
   greenButtonStyle,
   primaryButtonStyle,
@@ -53,72 +49,6 @@ export const UploadPhotos = () => {
 
   const handleCancel = () => {
     history("/");
-  };
-
-  const generateThumbnail = (folderName, file, quality) => {
-    new Compressor(file, {
-      quality: quality,
-      width: 600,
-      success(result) {
-        uploadFileHadler(folderName, result);
-      },
-      error(err) {
-        console.log(err.message);
-      },
-    });
-  };
-
-  const LoadImages = async () => {
-    const querySnapShot = await getDocs(collection(db, "images"));
-
-    querySnapShot.forEach((doc) => {
-      console.log(doc.id, doc.data());
-    });
-  };
-
-  const uploadFiles = () => {
-    if (fileName.length === 0) {
-      alert("Import File");
-    } else {
-      // const thumbnailArr = []
-
-      // forEach()
-      // generateThumbnail()
-      for (let i = 0; i < fileName.length; i++) {
-        uploadFileHadler("images", fileName[i]);
-        generateThumbnail("thumbnail", fileName[i], 1);
-        generateThumbnail("lowres", fileName[i], 0.1);
-      }
-      //uploadFileHadler(fileName);
-    }
-  };
-
-  const uploadFileHadler = (folderLocation, file) => {
-    //    console.log(file);
-    const storageRef = ref(storage, `${folderLocation}/${file.name}`);
-    // console.log(storageRef);
-    const uploadTask = uploadBytesResumable(storageRef, file);
-    uploadTask.on(
-      "state_changed",
-      (snapshot) => {
-        const progress =
-          (snapshot.bytesTransferred / snapshot.totalBytes) * 100;
-        setProgress(progress);
-      },
-      (err) => {
-        console.log(err);
-      },
-      () => {
-        getDownloadURL(uploadTask.snapshot.ref).then((downloadURL) => {
-          console.log("File available at", downloadURL);
-
-          const imageRef = doc(db, folderLocation, file.name);
-          setDoc(imageRef, {
-            imgUrl: downloadURL,
-          });
-        });
-      },
-    );
   };
 
   const uploadPhotoOnNode = (e) => {

--- a/src/App/Body.js
+++ b/src/App/Body.js
@@ -1,6 +1,6 @@
 /** @format */
 
-import React, { useEffect } from "react";
+import React from "react";
 
 import { Route, Routes } from "react-router-dom";
 
@@ -26,9 +26,6 @@ import Login from "./Login";
 import { Profile } from "./Demo/Container/Profile";
 import { UnAuthUser } from "./Components/UnAuthUser";
 
-import { useDispatch } from "react-redux";
-import { updateCurrentUser } from "./Store/Reducers/appSlice";
-import { auth } from "../firebase-config";
 import { Post } from "./Demo/Components/Post";
 import { Admin } from "./Components/Admin";
 
@@ -37,14 +34,6 @@ import { UploadPhotos } from "./About/Components/uploadPhotos";
 // import StockPhotos from "./StockPhotos/StockPhotos";
 
 export const Body = () => {
-  const dispatch = useDispatch();
-
-  useEffect(() => {
-    auth.onAuthStateChanged((user) => {
-      dispatch(updateCurrentUser(user?.email));
-    });
-  }, []);
-
   return (
     <>
       <div

--- a/src/App/Components/Admin.js
+++ b/src/App/Components/Admin.js
@@ -13,17 +13,6 @@ import {
   secondaryButtonStyle,
   warningButtonStyle,
 } from "../Utils/constants";
-import { db } from "../../firebase-config";
-
-import {
-  collection,
-  getDocs,
-  doc,
-  updateDoc,
-  deleteDoc,
-  setDoc,
-  addDoc,
-} from "firebase/firestore";
 import ToggleButton from "./ToggleButton";
 
 export const Admin = () => {
@@ -31,8 +20,6 @@ export const Admin = () => {
   const [editorData, setEditorData] = useState("");
   const [title, setTitle] = useState("");
   const languages = ["HTML", "CSS", "JavaScript", "React", "Redux"];
-
-  const userCollectionRef = collection(db, "Posts");
 
   const editorConfiguration = {
     toolbar: ["bold", "italic"],
@@ -50,19 +37,8 @@ export const Admin = () => {
   //   console.log(editorData);
   // };
 
-  const addPost = async () => {
-    console.log("dropdown");
-    const data = {
-      title,
-      description: editorData,
-      tags: ["javascript"],
-      date: Date.now(),
-    };
-    const res = await addDoc(userCollectionRef, data);
-    console.log(res.id);
-    setEditorData("");
-    setTitle("");
-    //TODO: clear ck editor data after successful post
+  const addPost = () => {
+    alert("Posting is currently unavailable.");
   };
   return (
     <>

--- a/src/App/Demo/Components/Posts.js
+++ b/src/App/Demo/Components/Posts.js
@@ -14,8 +14,6 @@ import { Button } from "react-bootstrap";
 import { Modal } from "./Modal/Modal";
 import { showHideModal } from "../../Store/Reducers/modalSlice";
 import { NavLink, Link, useLocation } from "react-router-dom";
-import { db } from "../../../firebase-config";
-import { collection, getDocs } from "firebase/firestore";
 
 export function Posts({ onLoadPostDescription, onDeletePost }) {
   // const { posts, isLoading } = useSelector((state) => state.postReducer);
@@ -30,18 +28,7 @@ export function Posts({ onLoadPostDescription, onDeletePost }) {
 
   let html = "";
   const fetchBlogs = async () => {
-    const userCollectionRef = collection(db, "Posts");
-
-    const data = await getDocs(userCollectionRef);
-    // setPosts(data);
-
-    const posts = [];
-
-    data.docs.map((i) => {
-      posts.push(i.data());
-    });
-
-    setPosts(posts);
+    setPosts([]);
   };
 
   const monthArr = [

--- a/src/App/Demo/Components/Users/Users.js
+++ b/src/App/Demo/Components/Users/Users.js
@@ -9,25 +9,15 @@ import {
   deleteButton,
 } from "../../../Utils/constants";
 
-import { db } from "../../../../firebase-config";
-import {
-  collection,
-  getDocs,
-  doc,
-  updateDoc,
-  deleteDoc,
-} from "firebase/firestore";
 import { MessageBox } from "../../../Components/MessageBox";
 
 const Users = () => {
   const [users, setUsers] = useState([]);
-  const userCollectionRef = collection(db, "user");
   const messageBoxRef = useRef(null);
   const history = useNavigate();
 
   const getUser = async () => {
-    const data = await getDocs(userCollectionRef);
-    setUsers(data.docs.map((doc) => ({ ...doc.data(), id: doc.id })));
+    setUsers([]);
   };
 
   useEffect(() => {
@@ -44,11 +34,8 @@ const Users = () => {
     }
   };
 
-  const deleteHandler = (id) => {
-    // messageBoxRef.current.showMessageBox();
-    const userDoc = doc(db, "user", id);
-    deleteDoc(userDoc, id);
-    getUser();
+  const deleteHandler = () => {
+    alert("Deleting users is currently unavailable.");
   };
 
   const update = (id, value) => {

--- a/src/App/Demo/Container/Profile.js
+++ b/src/App/Demo/Container/Profile.js
@@ -4,8 +4,6 @@ import React, { useEffect, useRef, useState } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 import { TextInputField } from "../../Components/TextInputField";
 import { warningButtonStyle, primaryButtonStyle } from "../../Utils/constants";
-import { db } from "../../../firebase-config";
-import { collection, addDoc, updateDoc, doc } from "firebase/firestore";
 
 export const Profile = () => {
   /** Passing  state  (data)  with location object for Edit User */
@@ -20,7 +18,6 @@ export const Profile = () => {
   const passwordRef = useRef(null);
   const confirmPasswordRef = useRef(null);
   const userNameRef = useRef(null);
-  const userCollectionRef = collection(db, "user");
 
   const allRefs = [
     { firstName: firstNameRef },
@@ -57,26 +54,14 @@ export const Profile = () => {
     }
   };
 
-  const updateUser = async (evt) => {
-    const userDoc = doc(db, "user", state.id);
-    await updateDoc(userDoc, { ...collectData(evt) });
+  const updateUser = (evt) => {
+    alert("Updating users is currently unavailable.");
     handleReset(evt);
     history("/users");
   };
 
-  const createUser = async (evt) => {
-    await addDoc(userCollectionRef, { ...collectData(evt) });
-  };
-
-  const collectData = (evt) => {
-    let dataCollection = {};
-    allRefs.forEach((item) => {
-      Object.entries(item).forEach(([key, value]) => {
-        dataCollection = { ...dataCollection, [key]: value.current.getValue() };
-      });
-    });
-
-    return dataCollection;
+  const createUser = () => {
+    alert("Creating users is currently unavailable.");
   };
 
   const handleCancel = (e) => {

--- a/src/App/Login.js
+++ b/src/App/Login.js
@@ -2,32 +2,21 @@
 
 import React, { useEffect, useRef, useState } from "react";
 import { NavLink, useNavigate, useLocation } from "react-router-dom";
-import { auth } from "../firebase-config";
 import { TextInputField } from "./Components/TextInputField";
 import {
   primaryButtonStyle,
   warningButtonStyle,
   secondaryButtonStyle,
 } from "./Utils/constants";
-import {
-  createUserWithEmailAndPassword,
-  signOut,
-  signInWithEmailAndPassword,
-} from "firebase/auth";
-import { useDispatch, useSelector } from "react-redux";
-import { updateCurrentUser } from "./Store/Reducers/appSlice";
-import { init } from "./LoginCanvas";
-import { initDancingLetter } from "./dancingLetter";
 
 const Login = () => {
   const navigate = useNavigate();
   const location = useLocation();
   const history = useNavigate();
-  const dispatch = useDispatch();
 
   const [isLogin, setIsLogin] = useState();
   const [error, setError] = useState(null);
-  const [isLoading, setLoading] = useState(false);
+  const [isLoading] = useState(false);
 
   useEffect(() => {
     console.log(location.pathname);
@@ -48,61 +37,16 @@ const Login = () => {
 
   const allRefs = [{ password: passwordRef }, { userName: userNameRef }];
 
-  const handleSubmit = async (evt) => {
+  const handleSubmit = (evt) => {
     evt.preventDefault();
-    setError("");
-    const email = userNameRef.current.getValue();
-    const password = passwordRef.current.getValue();
-    setLoading(true);
-    if (isLogin) {
-      // Login
-      try {
-        const user = await signInWithEmailAndPassword(
-          auth,
-          email.toString(),
-          password
-        );
-        history("/");
-      } catch (error) {
-        setError(error.message);
-      }
-      setLoading(false);
-    } else {
-      // Signup
-      try {
-        const user = await createUserWithEmailAndPassword(
-          auth,
-          email,
-          password
-        );
-        dispatch(updateCurrentUser(user.user.email));
-        history("/");
-      } catch (error) {
-        setLoading(false);
-        setError(error.message);
-      }
-    }
-  };
-
-  const handleLogin = async (evt) => {
-    evt.preventDefault();
-    const email = userNameRef.current.getValue();
-    const password = passwordRef.current.getValue();
-    setLoading(true);
-    try {
-      const user = await signInWithEmailAndPassword(auth, email, password);
-      history("/");
-    } catch (error) {
-      setError(error.message);
-    }
-    setLoading(false);
+    setError(
+      isLogin
+        ? "Login is currently unavailable."
+        : "Registration is currently unavailable."
+    );
   };
 
   useEffect(() => {
-    auth.onAuthStateChanged((user) => {
-      dispatch(updateCurrentUser(user?.email));
-    });
-
     const listener = (event) => {
       if (event.code === "Enter" || event.code === "NumpadEnter") {
         console.log("Enter key was pressed. Run your function.");

--- a/src/App/Navigation/navigation.js
+++ b/src/App/Navigation/navigation.js
@@ -5,8 +5,6 @@ import { useDispatch, useSelector } from "react-redux";
 
 import { ChildNav } from "../Demo/ChildNav";
 
-import { signOut } from "firebase/auth";
-import { auth } from "../../firebase-config";
 import { NavLink, useNavigate, useLocation } from "react-router-dom";
 import { blurBackground } from "../Utils/constants";
 import { updateCurrentUser } from "../Store/Reducers/appSlice";
@@ -35,8 +33,7 @@ const Navigation = () => {
   const appReducer = useSelector((state) => state.appReducer);
   const { menus, isAuthenticated } = appReducer;
 
-  const handleLogout = async () => {
-    await signOut(auth);
+  const handleLogout = () => {
     dispatch(updateCurrentUser());
     history("/");
   };

--- a/src/App/Photography/Components/Photos.js
+++ b/src/App/Photography/Components/Photos.js
@@ -1,11 +1,9 @@
 /** @format */
 
 import React, { useEffect, useState } from "react";
-import { db } from "../../../firebase-config";
 import "./Photos.css";
 import { LargeImage } from "./LargeImage";
 import Thumbnail from "./Thumbnail";
-import { collection, getDocs } from "firebase/firestore";
 import { useDispatch, useSelector } from "react-redux";
 import { setShowLargeImage } from "../../Store/Reducers/gallerySlice";
 import gallery from "./data";

--- a/src/App/Store/Reducers/gallerySlice.js
+++ b/src/App/Store/Reducers/gallerySlice.js
@@ -1,8 +1,6 @@
 /** @format */
 
 import { createSlice } from "@reduxjs/toolkit";
-import { collection, getDocs } from "firebase/firestore";
-import { db } from "../../../firebase-config";
 
 const initialState = {
   status: "",


### PR DESCRIPTION
## Summary
`src/firebase-config.js` is gitignored (holds real credentials), so it doesn't exist on Vercel — every file importing it failed the build with `Module not found: Error: Can't resolve '../firebase-config'`. This removes all `firebase-config` / `firebase/*` imports:

- **Login**: sign-in/sign-up now show a "currently unavailable" message instead of calling Firebase Auth; logout no longer calls `signOut`
- **Admin "Create Post"**, **Demo Profile** (create/update user), **Demo Users** (list/delete): Firestore calls replaced with disabled notices / empty state — there's no backend to hit without Firebase
- **Posts page**: Firestore fetch replaced with empty state
- **Photography gallery**, **gallerySlice**, **uploadPhotos**: removed already-dead Firebase code paths that weren't actually wired up (the gallery already reads from local static data; the working photo-upload path already goes through `axios` to a local server, not Firebase Storage)

Acknowledged consequence: login, the admin panel, and Firestore-backed CRUD (Posts/Users/Profile) are now non-functional everywhere, not just Vercel — this was the explicitly agreed scope.

## Test plan
- [x] `npm run build` succeeds
- [x] Verified in dev server (`npm start`) that the app still loads
